### PR TITLE
Removes passing the clock and reset with o_clk and o_resetn done in a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # FreeAHB (Experimental)
+Original author: Revanth Kamaraj (revanth91kamaraj@gmail.com)
+Somewhat extended by: Kris Monsen
 
-This fork is working on adding the full spec (HLOCK and HPROT missing), and testing it on a verified AHB bus environment. We also hope to add wrapping bursts and verification for all possible behaviors (especially SPLIT, RETRY, and ERROR slave responses)
+Modifications:
+- Adds bash script for running simulator.
+- Adds HLOCK and HPROT signals, which were missing in the original design.
+- Renames some variables in order to clarify what they do. o_dav is instead o_ready (the outputted data is ready) to follow the standard valid-ready memory request cycle.
+- Else... very little so far. We hope to add wrapping burst functionality sometime early summer, then add a sample slave and arbiter as well (currently the TBs only mimic the two). Right now this is just used as part of a thesis design which is prioritized over a fully functional AHB master (most masters can make do with single transfers). 
 
-Author: Revanth Kamaraj (revanth91kamaraj@gmail.com)
+
+END OF FORK README
+START OF ORIGINAL README
 
 This repository currently provides an AHB 2.0 Master.
 Icarus Verilog 10.0 or higher is required to simulate the design.
+
 
 ## Features of the AHB master:
 

--- a/ahb_master/sources/ahb_master.v
+++ b/ahb_master/sources/ahb_master.v
@@ -43,7 +43,8 @@
  * - Rename i_valid to i_valid and o_dav to o_ready to make it more clear what the signals are.
 */
 
-
+// Stage 1 refers to the address and control stage.
+// Stage 2 refers to the data phase(s) that follow.
 module ahb_master #(parameter DATA_WDT = 32, parameter BEAT_WDT = 32) (
         /************************
          * AHB interface.
@@ -86,6 +87,7 @@ module ahb_master #(parameter DATA_WDT = 32, parameter BEAT_WDT = 32) (
         output reg  [DATA_WDT-1:0]  o_data,     // Data got from AHB is presented here.
         output reg  [31:0]          o_addr,     // Corresponding address is presented here.
         output reg                  o_ready,     // Used as o_data valid indicator.
+
 
         // Also add prot and lock to UI
         input       [3:0]           i_prot,
@@ -199,6 +201,7 @@ wire b1k_spec      = (haddr[0] + (1 << i_size)) >> 10 != haddr[0][31:10];
 always @* {o_haddr, o_hburst, o_htrans, o_hwdata, o_hwrite, o_hsize, o_hprot, o_hlock} =
           {haddr[0], hburst, htrans[0], hwdata[1], hwrite[0], hsize[0], hprot, hlock};
 
+
 /* UI must change only if this is 1. */
 always @* o_next = (i_hready && i_hgrant && !pend_split);
 
@@ -210,8 +213,8 @@ always @ (posedge i_hclk or negedge i_hreset_n)
 begin
         if ( !i_hreset_n )
                 hgrant <= 2'd0;
-        else if ( spl_ret_cyc_1 && i_hresp == SPLIT)
-                hgrant <= 2'd0; /* A split retry cycle 1 AND a second split will invalidate the pipeline. TODO: Should also be HREADY*/
+        else if ( spl_ret_cyc_1 )
+                hgrant <= 2'd0; /* A split retry cycle 1 will invalidate the pipeline. */
         else if ( i_hready )
                 hgrant <= {hgrant[0], i_hgrant};
 end
@@ -246,11 +249,11 @@ begin
         end
         else if ( i_hready && i_hgrant )
         begin
-                pend_split <= 1'd0; /* Any pending split will be cleared, unblocking assignment = value accessible on next event. */
+                pend_split <= 1'd0; /* Any pending split will be cleared */ //TODO: But doesnt this make the first case under here unreachable?
 
-                if ( pend_split && i_hresp == SPLIT)
+                if ( pend_split )
                 begin
-                        /* If there's a pending split this cycle, perform a pipeline rollback */
+                        /* If there's a pending split, perform a pipeline rollback */
 
                         {hwdata[0], hwrite[0], hsize[0]} <= {hwdata[1], hwrite[1], hsize[1]};
 
@@ -264,19 +267,17 @@ begin
                 begin
                         {hwdata[0], hwrite[0], hsize[0]} <= {i_data, i_write, i_size};
 
-                        // If a transfer has not continued, and there is no valid data.
                         if ( !i_cont && !rd_wr ) /* Signal IDLE. */
                         begin
                                 htrans[0] <= IDLE;
                         end
-
-                        // If it is the potential start of a transfer, or if we are crossing address boundaries.
-                        // Determine if we should start a transfer, or conditions say we are idle
-                        // TODO: Would it be better to split these? Are all the cases really necessary?
                         else if ( (!i_cont && rd_wr) || !hgrant[0] || (burst_ctr == 1 && o_hburst != INCR)
-                                     || htrans[0] == IDLE || b1k_spec )
+                                     || htrans[0] == IDLE || b1k_spec ) // Second case: If we previously were not granted the bus.
+                                                                        // TODO: Can the burst really be changed mid-transfer?
+                                                                        // I guess this is in regards with split/retry restarting.
                         begin
                                 /* We need to recompute the burst type here */
+
                                 haddr[0]  <= !i_cont ? i_addr : haddr[0] + (rd_wr << i_size); // If this is not mid-burst?
                                 hburst    <= compute_hburst   (!i_cont ? i_min_len : beat_ctr,
                                                                !i_cont ? i_addr : haddr[0] + (rd_wr << i_size) , i_size);
@@ -287,15 +288,15 @@ begin
 
                                 beat_ctr  <= !i_cont ? i_min_len : ((hburst == INCR) ? beat_ctr : beat_ctr - rd_wr);
 
+                                // TODO: Test if this suffices for prot..
                                 hprot <= i_prot;
                                 hlock <= i_lock;
 
                         end
-
-                        // This is in the middle of an uninterrupted burst.
-                        // Insert a busy if the data is not yet valid, else call it sequential.
                         else
                         begin
+                                /* We are in a normal burst. No need to change HBURST. */
+
                                 haddr[0]  <= haddr[0] + ((htrans[0] != BUSY) << i_size);
                                 htrans[0] <= rd_wr ? SEQ : BUSY;
                                 burst_ctr <= o_hburst == INCR ? burst_ctr : (burst_ctr - rd_wr);

--- a/ahb_master/tmp/.gitinclude
+++ b/ahb_master/tmp/.gitinclude
@@ -1,0 +1,1 @@
+plskeep


### PR DESCRIPTION
… recent commit, updates README, adds tmp folder in order to support the scripted bash flow.

The reason we remove o_clk and o_resetn is that you usually would want to pass HCLK and HRESETn directly to the affected modules.
By passing the clock through the FreeAHB master, as done until now, it will make the critical path for the two signals longer than needed,
and you would add unneccessary clock propagation delay in the final implemented design. It also makes designs a bit neater.